### PR TITLE
chore: add php 8.5 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: PHPUnit
         run: |
-          vendor/bin/phpunit --colors --display-deprecation --coverage-text --coverage-clover coverage/clover.xml
+          vendor/bin/phpunit --colors --display-all-issues --coverage-text --coverage-clover coverage/clover.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   test:
@@ -26,6 +27,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout
@@ -55,12 +57,13 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Lint
+        if: matrix.php-version == '8.4'
         run: |
-          PHP_CS_FIXER_IGNORE_ENV=True vendor/bin/php-cs-fixer fix --diff --dry-run
+          vendor/bin/php-cs-fixer fix --diff --dry-run
 
       - name: PHPUnit
         run: |
-          vendor/bin/phpunit --colors --coverage-text --coverage-clover coverage/clover.xml
+          vendor/bin/phpunit --colors --display-deprecation --coverage-text --coverage-clover coverage/clover.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --display-deprecation --coverage-html ./coverage"
+            "phpunit --colors --display-all-issues --coverage-html ./coverage"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --coverage-html ./coverage"
+            "phpunit --colors --display-deprecation --coverage-html ./coverage"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "rancoud/http",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Http.git",
-                "reference": "3a226fff7aa162129ed04d23b8fc27970c8a6940"
+                "reference": "3e71657659da5cb33f6bff76ec65100c0a0b845a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Http/zipball/3a226fff7aa162129ed04d23b8fc27970c8a6940",
-                "reference": "3a226fff7aa162129ed04d23b8fc27970c8a6940",
+                "url": "https://api.github.com/repos/rancoud/Http/zipball/3e71657659da5cb33f6bff76ec65100c0a0b845a",
+                "reference": "3e71657659da5cb33f6bff76ec65100c0a0b845a",
                 "shasum": ""
             },
             "require": {
@@ -54,9 +54,9 @@
             "description": "Http package",
             "support": {
                 "issues": "https://github.com/rancoud/Http/issues",
-                "source": "https://github.com/rancoud/Http/tree/5.0.1"
+                "source": "https://github.com/rancoud/Http/tree/5.0.2"
             },
-            "time": "2026-03-15T12:03:51+00:00"
+            "time": "2026-05-31T18:09:17+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1191,6 +1191,7 @@ class RouterTest extends TestCase
         $middleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
         $response = (new Factory())->createResponse(404)->withBody(Stream::create('404'));
         $middleware->method('process')->willReturn($response);
+        $middleware->expects(static::once())->method('process');
 
         $request = (new Factory())->createServerRequest('GET', '/');
         $this->router->setDefault404($middleware);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
Here are some tips for you:  
1. If this PR is still in in Progress, put it in draft.
2. If this PR is introducing a breaking change please prefix with *BREAKING* in PR title.
3. If this PR has any follow up tasks, please prefix with *TODO* and describe follow up task.
4. When PR is ready to be reviewed, please tag rancoud as a sole reviewer.
-->
# Description
* add php 8.5 to test workflow
* avoid double run on github action
* add `--display-all-issues` on phpunit command
* remove lint action on php 8.5
* remove `PHP_CS_FIXER_IGNORE_ENV=True` for lint
* update dependency `rancoud/http` from 5.0.1 to 5.0.2